### PR TITLE
Add OSPF, SCION, and HTTP Checks, plus YAML Configuration & CSV Reports

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ python3 -m kathara_lab_checker --config <path-to-the-configuration-file> --labs 
 ```
 
 At this point, the tool parses the provided configuration file and executes the tests. For each network scenario the
-tool creates a `test_results.xlsx` file in the network scenario directory.
+tool creates a report file in the network scenario directory.
 
 The file is composed of three sheets:
 
@@ -33,7 +33,9 @@ The file is composed of three sheets:
 2. `All`: Contains the results for each test.
 3. `Failed`: Contains only the results of failed tests.
 
-After all the network scenarios are tested, the tool outputs an excell file `results.xlsx` in the network scenarios
+By default, reports are generated as a set of CSV files; however, you can choose to generate a consolidated Excel spreadsheet or disable report generation entirely using the `--report-type` flag.
+
+After all the network scenarios are tested, a combined report (either `results.xlsx` or `results.csv`, as selected) is placed in the network scenarios
 directory containing all the results for each network scenario, including the reasons for failed tests.
 
 ## Running the example

--- a/README.md
+++ b/README.md
@@ -56,6 +56,15 @@ The `--no-cache` flag force to repeat already executed tests.
 
 ## How to configure?
 
+The `structure` file can be written in either **JSON** or **YAML** format. With **YAML**, you may inline your Kathará lab structure under `lab_inline`. If you specify it like in the following, the tool uses it as your `structure` file automatically.
+
+```yaml
+lab_inline: |
+  router1[0]="net12"
+  router2[0]="net12"
+  ...
+```
+
 In the following you will find the possible values for the configuration file.
 
 ```

--- a/examples/ospf_http/correction.yaml
+++ b/examples/ospf_http/correction.yaml
@@ -1,0 +1,73 @@
+---
+labs_path: ospf
+convergence_time: 60
+lab_inline: |
+  router1[0]="net12"
+  router2[0]="net12"
+  router2[1]="net23"
+  router3[0]="net23"
+default_image: kathara/frr
+test:
+  requiring_startup:
+  - router1
+  - router2
+  - router3
+  protocols:
+    ospfd:
+      neighbors:
+        router1:
+        - router_id: 2.2.2.2
+          state: FULL
+        router2:
+        - router_id: 1.1.1.1
+          state: FULL
+        - router_id: 3.3.3.3
+          state: FULL
+        router3:
+        - router_id: 2.2.2.2
+          state: FULL
+      routes:
+        router1:
+        - route: 10.0.12.0/24
+        - route: 10.0.23.0/24
+        router2:
+        - route: 10.0.12.0/24
+        - route: 10.0.23.0/24
+        router3:
+        - route: 10.0.12.0/24
+        - route: 10.0.23.0/24
+      interfaces:
+        router1:
+          eth0:
+            ospfIfType: Broadcast
+            networkType: BROADCAST
+            cost: 10
+            state: Backup
+        router2:
+          eth0:
+            ospfIfType: Broadcast
+            networkType: BROADCAST
+            cost: 10
+            state: DR
+          eth1:
+            ospfIfType: Broadcast
+            networkType: BROADCAST
+            cost: 10
+            state: Backup
+        router3:
+          eth0:
+            ospfIfType: Broadcast
+            networkType: BROADCAST
+            cost: 10
+            state: DR
+  applications:
+    http:
+      router1:
+      - url: http://10.0.23.3/
+        status_code: 200
+        body_contains: Hello
+      router2:
+      - url: http://10.0.23.3/nonexistent
+        method: POST
+        status_code: 404
+

--- a/examples/ospf_http/lab/lab.conf
+++ b/examples/ospf_http/lab/lab.conf
@@ -1,0 +1,15 @@
+LAB_DESCRIPTION="A small kathara toy example"
+LAB_VERSION=1.0
+LAB_AUTHOR="E. Mairoll"
+LAB_EMAIL=emairoll@student.ethz.ch
+LAB_WEB=https://netsec.ethz.ch
+
+router1[0]="net12"
+router1[image]="kathara/frr"
+
+router2[0]="net12"
+router2[1]="net23"
+router2[image]="kathara/frr"
+
+router3[0]="net23"
+router3[image]="kathara/frr"

--- a/examples/ospf_http/lab/router1.startup
+++ b/examples/ospf_http/lab/router1.startup
@@ -1,0 +1,3 @@
+#!/bin/bash
+ip address add 10.0.12.1/24 dev eth0
+systemctl start frr

--- a/examples/ospf_http/lab/router1/etc/frr/daemons
+++ b/examples/ospf_http/lab/router1/etc/frr/daemons
@@ -1,0 +1,3 @@
+# FRR daemons file - Enables ospfd
+zebra=yes
+ospfd=yes

--- a/examples/ospf_http/lab/router1/etc/frr/frr.conf
+++ b/examples/ospf_http/lab/router1/etc/frr/frr.conf
@@ -1,0 +1,16 @@
+!
+! FRRouting configuration file
+!
+log file /var/log/frr/frr.log
+!
+!  OSPF CONFIGURATION
+!
+! Enable log output:
+debug ospf event
+debug ospf packet all
+
+! OSPF configuration block
+router ospf
+  ospf router-id 1.1.1.1
+  network 10.0.12.0/24 area 0
+!

--- a/examples/ospf_http/lab/router2.startup
+++ b/examples/ospf_http/lab/router2.startup
@@ -1,0 +1,4 @@
+#!/bin/bash
+ip address add 10.0.12.2/24 dev eth0
+ip address add 10.0.23.2/24 dev eth1
+systemctl start frr

--- a/examples/ospf_http/lab/router2/etc/frr/daemons
+++ b/examples/ospf_http/lab/router2/etc/frr/daemons
@@ -1,0 +1,3 @@
+# FRR daemons file - Enables ospfd
+zebra=yes
+ospfd=yes

--- a/examples/ospf_http/lab/router2/etc/frr/frr.conf
+++ b/examples/ospf_http/lab/router2/etc/frr/frr.conf
@@ -1,0 +1,17 @@
+!
+! FRRouting configuration file
+!
+log file /var/log/frr/frr.log
+!
+!  OSPF CONFIGURATION
+!
+! Enable log output:
+debug ospf event
+debug ospf packet all
+
+! OSPF configuration block
+router ospf
+  ospf router-id 2.2.2.2
+  network 10.0.12.0/24 area 0
+  network 10.0.23.0/24 area 0
+!

--- a/examples/ospf_http/lab/router3.startup
+++ b/examples/ospf_http/lab/router3.startup
@@ -1,0 +1,5 @@
+#!/bin/bash
+ip address add 10.0.23.3/24 dev eth0
+systemctl start frr
+systemctl start apache2
+

--- a/examples/ospf_http/lab/router3/etc/frr/daemons
+++ b/examples/ospf_http/lab/router3/etc/frr/daemons
@@ -1,0 +1,3 @@
+# FRR daemons file - Enables ospfd
+zebra=yes
+ospfd=yes

--- a/examples/ospf_http/lab/router3/etc/frr/frr.conf
+++ b/examples/ospf_http/lab/router3/etc/frr/frr.conf
@@ -1,0 +1,16 @@
+!
+! FRRouting configuration file
+!
+log file /var/log/frr/frr.log
+!
+!  OSPF CONFIGURATION
+!
+! Enable log output:
+debug ospf event
+debug ospf packet all
+
+! OSPF configuration block
+router ospf
+  ospf router-id 3.3.3.3
+  network 10.0.23.0/24 area 0
+!

--- a/src/kathara_lab_checker/__main__.py
+++ b/src/kathara_lab_checker/__main__.py
@@ -43,6 +43,8 @@ from .checks.protocols.bgp.BGPRoutesCheck import BGPRoutesCheck
 from .checks.protocols.evpn.AnnouncedVNICheck import AnnouncedVNICheck
 from .checks.protocols.evpn.EVPNSessionCheck import EVPNSessionCheck
 from .checks.protocols.evpn.VTEPCheck import VTEPCheck
+from .checks.protocols.scion.SCIONAddressCheck import SCIONAddressCheck
+from .checks.protocols.scion.SCIONPathsCheck import SCIONPathsCheck
 from .excel_utils import write_final_results_to_excel, write_result_to_excel
 from .model.CheckResult import CheckResult
 from .utils import reverse_dictionary
@@ -222,7 +224,17 @@ def run_on_single_network_scenario(
                     logger.info("Checking OSPF interface parameters...")
                     check_results = OSPFInterfaceCheck(lab).run(daemon_test["interfaces"])
                     test_collector.add_check_results(lab_name, check_results)
-                
+
+            if daemon_name == "sciond":
+                if "address" in daemon_test:
+                    logger.info("Checking SCION addresses...")
+                    check_results = SCIONAddressCheck(lab).run(daemon_test["address"])
+                    test_collector.add_check_results(lab_name, check_results)
+                if "paths" in daemon_test:
+                    logger.info("Checking SCION paths...")
+                    check_results = SCIONPathsCheck(lab).run(daemon_test["paths"])
+                    test_collector.add_check_results(lab_name, check_results)
+
             if "injections" in daemon_test:
                 logger.info(f"Checking {daemon_name} protocols redistributions...")
                 check_results = ProtocolRedistributionCheck(lab).run(daemon_name, daemon_test["injections"])

--- a/src/kathara_lab_checker/__main__.py
+++ b/src/kathara_lab_checker/__main__.py
@@ -32,6 +32,7 @@ from .checks.StartupExistenceCheck import StartupExistenceCheck
 from .checks.SysctlCheck import SysctlCheck
 from .checks.applications.dns.DNSAuthorityCheck import DNSAuthorityCheck
 from .checks.applications.dns.DNSRecordCheck import DNSRecordCheck
+from .checks.applications.http.HTTPCheck import HTTPCheck
 from .checks.applications.dns.LocalNSCheck import LocalNSCheck
 from .checks.protocols.AnnouncedNetworkCheck import AnnouncedNetworkCheck
 from .checks.protocols.ProtocolRedistributionCheck import ProtocolRedistributionCheck
@@ -268,6 +269,11 @@ def run_on_single_network_scenario(
                         application["records"], reverse_dictionary(application["local_ns"]).keys()
                     )
                     test_collector.add_check_results(lab_name, check_results)
+
+            if application_name == "http":
+                logger.info("Checking HTTP endpoints via cURL...")
+                check_results = HTTPCheck(lab).run(application)
+                test_collector.add_check_results(lab_name, check_results)            
 
     if "custom_commands" in configuration["test"]:
         logger.info("Checking custom commands output...")

--- a/src/kathara_lab_checker/__main__.py
+++ b/src/kathara_lab_checker/__main__.py
@@ -35,6 +35,9 @@ from .checks.applications.dns.DNSRecordCheck import DNSRecordCheck
 from .checks.applications.dns.LocalNSCheck import LocalNSCheck
 from .checks.protocols.AnnouncedNetworkCheck import AnnouncedNetworkCheck
 from .checks.protocols.ProtocolRedistributionCheck import ProtocolRedistributionCheck
+from .checks.protocols.ospf.OSPFNeighborCheck import OSPFNeighborCheck
+from .checks.protocols.ospf.OSPFRoutesCheck import OSPFRoutesCheck
+from .checks.protocols.ospf.OSPFInterfaceCheck import OSPFInterfaceCheck
 from .checks.protocols.bgp.BGPNeighborCheck import BGPNeighborCheck
 from .checks.protocols.bgp.BGPRoutesCheck import BGPRoutesCheck
 from .checks.protocols.evpn.AnnouncedVNICheck import AnnouncedVNICheck
@@ -206,6 +209,20 @@ def run_on_single_network_scenario(
                             )
                             test_collector.add_check_results(lab_name, check_results)
 
+            if daemon_name == "ospfd":
+                if "neighbors" in daemon_test:
+                    logger.info("Checking OSPF neighbors...")
+                    check_results = OSPFNeighborCheck(lab).run(daemon_test["neighbors"])
+                    test_collector.add_check_results(lab_name, check_results)
+                if "routes" in daemon_test:
+                    logger.info("Checking OSPF routes...")
+                    check_results = OSPFRoutesCheck(lab).run(daemon_test["routes"])
+                    test_collector.add_check_results(lab_name, check_results)
+                if "interfaces" in daemon_test:
+                    logger.info("Checking OSPF interface parameters...")
+                    check_results = OSPFInterfaceCheck(lab).run(daemon_test["interfaces"])
+                    test_collector.add_check_results(lab_name, check_results)
+                
             if "injections" in daemon_test:
                 logger.info(f"Checking {daemon_name} protocols redistributions...")
                 check_results = ProtocolRedistributionCheck(lab).run(daemon_name, daemon_test["injections"])

--- a/src/kathara_lab_checker/checks/applications/http/HTTPCheck.py
+++ b/src/kathara_lab_checker/checks/applications/http/HTTPCheck.py
@@ -1,0 +1,100 @@
+import re
+from Kathara.exceptions import MachineNotRunningError
+from ...AbstractCheck import AbstractCheck
+from ....model.CheckResult import CheckResult
+from ....utils import get_output
+
+class HTTPCheck(AbstractCheck):
+    """
+    Execute HTTP checks using curl on the remote device.
+    """
+
+    def check(self, device_name: str, test_params: dict) -> list[CheckResult]:
+        """
+        Runs curl on the device with the given parameters:
+          {
+            "url": "<required>",
+            "method": "<optional, default=GET>",
+            "status_code": 200,
+            "regex_body": "<regex to match>",
+            "body_contains": "<literal substring>"
+          }
+        Returns one or more CheckResult objects.
+        """
+        results = []
+        url = test_params.get("url")
+        if not url:
+            desc = f"HTTP Check on {device_name} missing 'url'"
+            return [CheckResult(desc, False, "No 'url' provided")]
+
+        desc = f"HTTP check '{url}' on {device_name}"
+
+        method = test_params.get("method", "GET").upper()
+
+        # Use curl to output both body and HTTP code separated by a unique delimiter.
+        delimiter = "===CURL_STATUS==="
+        curl_cmd = f"curl -s -X {method} -w '{delimiter}%{{http_code}}' '{url}'"
+
+        try:
+            exec_output = self.kathara_manager.exec(
+                machine_name=device_name,
+                command=curl_cmd,
+                lab_hash=self.lab.hash
+            )
+        except MachineNotRunningError as e:
+            return [CheckResult(desc, False, str(e))]
+
+        combined_output = get_output(exec_output).strip()
+        if delimiter in combined_output:
+            body, code_str = combined_output.rsplit(delimiter, 1)
+        else:
+            body = combined_output
+            code_str = ""
+
+        expected_code = test_params.get("status_code", 200)
+        if not code_str.isdigit():
+            results.append(CheckResult(desc, False, f"curl output did not contain a valid status code: '{code_str}'"))
+        else:
+            actual_code = int(code_str)
+            if actual_code == expected_code:
+                results.append(CheckResult(f"{desc} status", True, f"HTTP {actual_code} == {expected_code}"))
+            else:
+                results.append(CheckResult(f"{desc} status", False,
+                    f"Expected HTTP {expected_code}, got {actual_code}"))
+
+        if "regex_body" in test_params or "body_contains" in test_params:
+            if "regex_body" in test_params:
+                regex = test_params["regex_body"]
+                regex_desc = f"{desc} body regex /{regex}/"
+                if re.search(regex, body):
+                    results.append(CheckResult(regex_desc, True, "OK"))
+                else:
+                    results.append(CheckResult(regex_desc, False, "Body does not match regex"))
+            
+            if "body_contains" in test_params:
+                substr = test_params["body_contains"]
+                substr_desc = f"{desc} body substring '{substr}'"
+                if substr in body:
+                    results.append(CheckResult(substr_desc, True, "OK"))
+                else:
+                    results.append(CheckResult(substr_desc, False, "Substring not found in body"))
+        
+        return results
+
+    def run(self, device_http_tests: dict[str, list[dict]]) -> list[CheckResult]:
+        """
+        device_http_tests = {
+          "device_name": [
+            { "url": "<required>", "method": "GET", "status_code": 200, "regex_body": "foo|bar" },
+            { "url": "<another_url>", "body_contains": "hello world" }
+          ],
+          ...
+        }
+        """
+        all_results = []
+        for device_name, checks in device_http_tests.items():
+            self.logger.info(f"Performing HTTP checks on {device_name}...")
+            for check_params in checks:
+                results = self.check(device_name, check_params)
+                all_results.extend(results)
+        return all_results

--- a/src/kathara_lab_checker/checks/protocols/ospf/OSPFInterfaceCheck.py
+++ b/src/kathara_lab_checker/checks/protocols/ospf/OSPFInterfaceCheck.py
@@ -1,0 +1,51 @@
+import json
+from Kathara.exceptions import MachineNotRunningError
+from ...AbstractCheck import AbstractCheck
+from ....model.CheckResult import CheckResult
+
+class OSPFInterfaceCheck(AbstractCheck):
+    def check(self, device_name: str, interface_name: str, expected: dict) -> list[CheckResult]:
+        results = []
+        base_desc = f"OSPF interface {interface_name} on {device_name}"
+        try:
+            stdout, stderr, exit_code = self.kathara_manager.exec(
+                machine_name=device_name,
+                command="vtysh -e 'show ip ospf interface json'",
+                lab_hash=self.lab.hash,
+                stream=False
+            )
+        except MachineNotRunningError as e:
+            return [CheckResult(base_desc, False, str(e))]
+        
+        output = stdout.decode("utf-8") if stdout else ""
+        if stderr or exit_code != 0:
+            err_msg = stderr.decode("utf-8") if stderr else f"Exit code: {exit_code}"
+            return [CheckResult(base_desc, False, err_msg)]
+        
+        try:
+            data = json.loads(output)
+        except Exception as e:
+            return [CheckResult(base_desc, False, f"JSON parse error: {str(e)}")]
+        
+        interfaces = data.get("interfaces", {})
+        if interface_name not in interfaces:
+            results.append(CheckResult(base_desc, False, f"Interface {interface_name} not found"))
+            return results
+        
+        iface = interfaces[interface_name]
+        for key, expected_value in expected.items():
+            actual_value = iface.get(key)
+            desc = f"{base_desc}: {key}"
+            if actual_value != expected_value:
+                results.append(CheckResult(desc, False, f"Expected {expected_value}, got {actual_value}"))
+            else:
+                results.append(CheckResult(desc, True, "OK"))
+        return results
+
+    def run(self, device_to_interface_expected: dict[str, dict[str, dict]]) -> list[CheckResult]:
+        results = []
+        for device_name, iface_dict in device_to_interface_expected.items():
+            self.logger.info(f"Checking OSPF interface parameters for {device_name}...")
+            for iface_name, expected in iface_dict.items():
+                results.extend(self.check(device_name, iface_name, expected))
+        return results

--- a/src/kathara_lab_checker/checks/protocols/ospf/OSPFNeighborCheck.py
+++ b/src/kathara_lab_checker/checks/protocols/ospf/OSPFNeighborCheck.py
@@ -1,0 +1,63 @@
+import json
+from Kathara.exceptions import MachineNotRunningError
+from ...AbstractCheck import AbstractCheck
+from ....model.CheckResult import CheckResult
+
+class OSPFNeighborCheck(AbstractCheck):
+    def check(self, device_name: str, expected_neighbors: list[dict]) -> list[CheckResult]:
+        results = []
+        self.description = f"Checking OSPF neighbors on {device_name}"
+        try:
+            stdout, stderr, exit_code = self.kathara_manager.exec(
+                machine_name=device_name,
+                command="vtysh -e 'show ip ospf neighbor json'",
+                lab_hash=self.lab.hash,
+                stream=False
+            )
+        except MachineNotRunningError as e:
+            return [CheckResult(self.description, False, str(e))]
+        output = stdout.decode("utf-8") if stdout else ""
+        if stderr or exit_code != 0:
+            err_msg = stderr.decode("utf-8") if stderr else f"Exit code: {exit_code}"
+            return [CheckResult(self.description, False, err_msg)]
+        try:
+            data = json.loads(output)
+        except Exception as e:
+            return [CheckResult(self.description, False, f"JSON parse error: {str(e)}")]
+
+        # Expect data to be a dict with a "neighbors" key that is also a dict.
+        if isinstance(data, dict) and "neighbors" in data:
+            neighbors_data = data["neighbors"]
+        else:
+            neighbors_data = {}
+
+        # For each expected neighbor, check presence and state.
+        for expected in expected_neighbors:
+            expected_id = expected.get("router_id")
+            # Default expected state is FULL (we compare in uppercase)
+            expected_state = expected.get("state", "FULL").upper()
+            check_desc = f"OSPF neighbor {expected_id} on {device_name}"
+            if expected_id not in neighbors_data:
+                results.append(CheckResult(check_desc, False, f"Neighbor with router_id {expected_id} not found"))
+                continue
+            # Get the list of neighbor info objects.
+            neighbor_entries = neighbors_data[expected_id]
+            matched = False
+            for entry in neighbor_entries:
+                # Use the "converged" field as the operational state.
+                actual_state = entry.get("converged", "").upper()
+                if actual_state == expected_state:
+                    results.append(CheckResult(check_desc, True, "OK"))
+                    matched = True
+                    break
+            if not matched:
+                first_state = neighbor_entries[0].get("converged", "UNKNOWN")
+                results.append(CheckResult(check_desc, False, f"State is {first_state}, expected {expected_state}"))
+        return results
+
+    def run(self, device_to_neighbors: dict[str, list[dict]]) -> list[CheckResult]:
+        results = []
+        for device_name, neighbors in device_to_neighbors.items():
+            self.logger.info(f"Checking OSPF neighbors for {device_name}...")
+            results.extend(self.check(device_name, neighbors))
+        return results

--- a/src/kathara_lab_checker/checks/protocols/ospf/OSPFRoutesCheck.py
+++ b/src/kathara_lab_checker/checks/protocols/ospf/OSPFRoutesCheck.py
@@ -1,0 +1,45 @@
+import json
+from Kathara.exceptions import MachineNotRunningError
+from ...AbstractCheck import AbstractCheck
+from ....model.CheckResult import CheckResult
+
+class OSPFRoutesCheck(AbstractCheck):
+    def check(self, device_name: str, expected_routes: list[dict]) -> list[CheckResult]:
+        results = []
+        self.description = f"Checking OSPF routes on {device_name}"
+        try:
+            stdout, stderr, exit_code = self.kathara_manager.exec(
+                machine_name=device_name,
+                command="vtysh -e 'show ip ospf route json'",
+                lab_hash=self.lab.hash,
+                stream=False
+            )
+        except MachineNotRunningError as e:
+            return [CheckResult(self.description, False, str(e))]
+        output = stdout.decode("utf-8") if stdout else ""
+        if stderr or exit_code != 0:
+            err_msg = stderr.decode("utf-8") if stderr else f"Exit code: {exit_code}"
+            return [CheckResult(self.description, False, err_msg)]
+        try:
+            data = json.loads(output)
+        except Exception as e:
+            return [CheckResult(self.description, False, f"JSON parse error: {str(e)}")]
+        
+        # If the JSON does not have a "routes" key, assume the top-level object is the routes dict.
+        ospf_routes = data.get("routes", data)
+        
+        for expected in expected_routes:
+            route = expected.get("route")
+            check_desc = f"OSPF route {route} on {device_name}"
+            if route not in ospf_routes:
+                results.append(CheckResult(check_desc, False, f"Route {route} not found"))
+            else:
+                results.append(CheckResult(check_desc, True, "OK"))
+        return results
+
+    def run(self, devices_to_routes: dict[str, list[dict]]) -> list[CheckResult]:
+        results = []
+        for device_name, routes in devices_to_routes.items():
+            self.logger.info(f"Checking OSPF routes for {device_name}...")
+            results.extend(self.check(device_name, routes))
+        return results

--- a/src/kathara_lab_checker/checks/protocols/scion/SCIONAddressCheck.py
+++ b/src/kathara_lab_checker/checks/protocols/scion/SCIONAddressCheck.py
@@ -1,0 +1,38 @@
+import re
+from Kathara.exceptions import MachineNotRunningError
+from ...AbstractCheck import AbstractCheck
+from ....model.CheckResult import CheckResult
+
+class SCIONAddressCheck(AbstractCheck):
+    def check(self, device_name: str, expected_address: str) -> CheckResult:
+        """
+        Executes 'scion address' on the device and compares the output to expected_address.
+        Expected format example: "42-ffaa:1:1,127.0.0.1"
+        """
+        self.description = f"Checking SCION address on {device_name}"
+        try:
+            stdout, stderr, exit_code = self.kathara_manager.exec(
+                machine_name=device_name,
+                command="scion address",
+                lab_hash=self.lab.hash,
+                stream=False
+            )
+        except MachineNotRunningError as e:
+            return CheckResult(self.description, False, str(e))
+        output = stdout.decode("utf-8").strip() if stdout else ""
+        if stderr or exit_code != 0:
+            err_msg = stderr.decode("utf-8") if stderr else f"Exit code: {exit_code}"
+            return CheckResult(self.description, False, err_msg)
+        if output == expected_address:
+            return CheckResult(self.description, True, "OK")
+        else:
+            return CheckResult(self.description, False, f"Expected '{expected_address}', got '{output}'")
+
+    def run(self, device_to_expected: dict[str, str]) -> list[CheckResult]:
+        """
+        Expects a mapping: { device_name: expected_scion_address }
+        """
+        results = []
+        for device_name, expected in device_to_expected.items():
+            results.append(self.check(device_name, expected))
+        return results

--- a/src/kathara_lab_checker/checks/protocols/scion/SCIONPathsCheck.py
+++ b/src/kathara_lab_checker/checks/protocols/scion/SCIONPathsCheck.py
@@ -1,0 +1,112 @@
+import json
+from Kathara.exceptions import MachineNotRunningError
+from ...AbstractCheck import AbstractCheck
+from ....model.CheckResult import CheckResult
+
+class SCIONPathsCheck(AbstractCheck):
+    def format_path(self, path: dict) -> str:
+        """
+        Formats a single path dictionary into a string representation 
+        with departure/arrival in the X>Y notation.
+        Collapses consecutive hops with the same 'isd_as'.
+        """
+        hops = path.get("hops", [])
+        if not hops:
+            return ""
+
+        # We'll build up a list of "nodes," each with "isd_as" + single interface 
+        # (both departure and arrival).
+        nodes = []
+        # Start with the first hop
+        first = hops[0]
+        nodes.append({
+            "isd_as": first.get("isd_as", ""),
+            "arr": first.get("interface"),
+            "dep": first.get("interface"),
+        })
+
+        for hop in hops[1:]:
+            current_as = hop.get("isd_as", "")
+            iface = hop.get("interface")
+            # If the last node is the same AS, update its 'dep'
+            if nodes and nodes[-1]["isd_as"] == current_as:
+                nodes[-1]["dep"] = iface
+            else:
+                nodes.append({
+                    "isd_as": current_as,
+                    "arr": iface,
+                    "dep": iface
+                })
+
+        formatted = nodes[0]["isd_as"]
+        for i in range(1, len(nodes)):
+            prev_dep = nodes[i - 1]["dep"]
+            curr_arr = nodes[i]["arr"]
+            formatted += f" {prev_dep}>{curr_arr} {nodes[i]['isd_as']}"
+
+        return formatted
+
+    def check(self, device_name: str, destination: str, expected_paths: list[str]) -> list[CheckResult]:
+        """
+        Runs 'scion showpaths <destination> --format json' and checks that each 
+        path in expected_paths is present in the returned list of actual paths.
+        """
+        desc_base = f"SCION paths from {device_name} to {destination}"
+        results = []
+
+        try:
+            cmd = f"scion showpaths {destination} --refresh --format json"
+            stdout, stderr, exit_code = self.kathara_manager.exec(
+                machine_name=device_name,
+                command=cmd,
+                lab_hash=self.lab.hash,
+                stream=False
+            )
+        except MachineNotRunningError as e:
+            return [CheckResult(desc_base, False, str(e))]
+
+        raw_output = stdout.decode("utf-8").strip() if stdout else ""
+        if stderr or exit_code != 0:
+            err_msg = stderr.decode("utf-8") if stderr else f"Exit code: {exit_code}"
+            return [CheckResult(desc_base, False, err_msg)]
+
+        try:
+            data = json.loads(raw_output)
+        except Exception as e:
+            return [CheckResult(desc_base, False, f"JSON parse error: {str(e)}")]
+
+        actual_paths = set()
+        for path_obj in data.get("paths", []):
+            formatted = self.format_path(path_obj)
+            if formatted:
+                actual_paths.add(formatted)
+
+        # For each expected path, check if it exists
+        for exp_path in expected_paths:
+            desc = f"{desc_base}: '{exp_path}'"
+            if exp_path in actual_paths:
+                results.append(CheckResult(desc, True, "OK"))
+            else:
+                results.append(CheckResult(desc, False, f"Path '{exp_path}' not found"))
+        return results
+
+    def run(self, device_destinations: dict[str, dict[str, list[str]]]) -> list[CheckResult]:
+        """
+        device_destinations = {
+          "device_name": {
+             "destination_1": [ "expPath1", "expPath2" ],
+             "destination_2": [ "expPath3" ],
+             ...
+          },
+          ...
+        }
+
+        For each device, we loop over all destinations, run 'check(device, destination, expectedPaths)'
+        for each, and aggregate results.
+        """
+        all_results = []
+        for device_name, destinations in device_destinations.items():
+            self.logger.info(f"Checking SCION showpaths for {device_name}...")
+            for dest, exp_paths in destinations.items():
+                all_results.extend(self.check(device_name, dest, exp_paths))
+        return all_results

--- a/src/kathara_lab_checker/csv_utils.py
+++ b/src/kathara_lab_checker/csv_utils.py
@@ -1,0 +1,62 @@
+import os
+import csv
+
+def write_final_results_to_csv(test_collector, path: str):
+    """
+    Writes the overall summary report for all labs.
+    The CSV contains the same columns as the Excel summary:
+    "Student Name", "Tests Passed", "Tests Failed", "Tests Total Number", "Problems".
+    """
+    csv_file = os.path.join(path, "results.csv")
+    with open(csv_file, mode="w", newline="", encoding="utf-8") as f:
+        writer = csv.writer(f)
+        writer.writerow(["Student Name", "Tests Passed", "Tests Failed", "Tests Total Number", "Problems"])
+        for lab_name, test_results in test_collector.tests.items():
+            failed_tests = [tr for tr in test_results if not tr.passed]
+            passed_tests = [tr for tr in test_results if tr.passed]
+            if failed_tests:
+                failed_string = ""
+                for idx, failed in enumerate(failed_tests, 1):
+                    failed_string += f"{idx}: {failed.description}: {failed.reason}\n"
+                # (Excel truncates long cells; CSV remains untruncated)
+            else:
+                failed_string = "None"
+            writer.writerow([lab_name, len(passed_tests), len(failed_tests), len(test_results), failed_string.strip()])
+
+
+def write_result_to_csv(check_results: list, path: str):
+    """
+    Writes detailed test results in three CSV files (mimicking Excel's multiple sheets):
+      - A summary CSV file (with total tests, passed tests, and failed tests).
+      - An "all" results CSV file (listing every test result).
+      - A "failed" results CSV file (listing only failed tests).
+    The files are named based on the base name of the given path.
+    """
+    base_name = os.path.basename(path)
+
+    # Summary CSV
+    summary_file = os.path.join(path, f"{base_name}_result_summary.csv")
+    with open(summary_file, mode="w", newline="", encoding="utf-8") as f:
+        writer = csv.writer(f)
+        writer.writerow(["Total Tests", "Passed Tests", "Failed"])
+        total = len(check_results)
+        passed = len([r for r in check_results if r.passed])
+        failed = len([r for r in check_results if not r.passed])
+        writer.writerow([total, passed, failed])
+
+    # "All" Results CSV
+    all_file = os.path.join(path, f"{base_name}_result_all.csv")
+    with open(all_file, mode="w", newline="", encoding="utf-8") as f:
+        writer = csv.writer(f)
+        writer.writerow(["Test Description", "Passed", "Reason"])
+        for r in check_results:
+            writer.writerow([r.description, r.passed, r.reason])
+
+    # "Failed" Results CSV
+    failed_file = os.path.join(path, f"{base_name}_result_failed.csv")
+    with open(failed_file, mode="w", newline="", encoding="utf-8") as f:
+        writer = csv.writer(f)
+        writer.writerow(["Test Description", "Passed", "Reason"])
+        for r in check_results:
+            if not r.passed:
+                writer.writerow([r.description, r.passed, r.reason])


### PR DESCRIPTION
# Pull Request Description

This PR adds several features and enhancements to the Kathará Lab Checker, which we will use in the upcoming "Computer Networks" course at ETH Zurich:

1. **Additional Protocol & Application Checks**
   - **OSPF**: Provides neighbor/route checks by parsing FRR JSON outputs (`vtysh -e "show ip ospf neighbor json"`, etc.).
   - **HTTP**: Adds an application-level check using curl to validate HTTP endpoints, status codes, and optional body matching (regex or substring).
   - **SCION**: Implements checks under the new sciond protocol to verify both addresses and paths.

2. **YAML Configuration & Inline Structure**
   - **YAML Support**: The checker can now parse config files as JSON or YAML (auto‐detected).
   - **Inline Structure**: If the user sets lab_inline as a multi-line string in YAML, that content is written to a temporary file and treated as the structure. This allows the entire correction definition to be contained in a single file.

3. **CSV Report Generation**
   - In addition to the default Excel (.xlsx) format, users can now select --report-type csv or none. This produces one .csv summary, plus per-lab details in CSV form, for users who prefer a lightweight text-based format.

All changes remain backward‐compatible with existing JSON configs and command line options.