### PR TITLE
Version 0.1.12

### DIFF
--- a/examples/palabra/correction.json
+++ b/examples/palabra/correction.json
@@ -1,6 +1,6 @@
 {
 	"convergence_time": 10,
-	"structure": "examples/palabra/structure",
+	"structure": "structure",
 	"default_image": "kathara/frr",
 	"test": {
 		"requiring_startup": [

--- a/src/kathara_lab_checker/__main__.py
+++ b/src/kathara_lab_checker/__main__.py
@@ -158,11 +158,11 @@ def run_on_multiple_network_scenarios(
         if test_results:
             test_collector.add_check_results(lab_name, test_results.tests[lab_name])
 
-    if test_collector.tests and report_type != "none":
+    if test_collector.tests:
         logger.info(f"Writing All Test Results into: {labs_path} as {report_type.upper()} report...")
         if report_type == "xlsx":
             write_final_results_to_excel(test_collector, labs_path)
-        elif report_type == "csv":
+        else:
             from .csv_utils import write_final_results_to_csv
             write_final_results_to_csv(test_collector, labs_path)
 
@@ -226,7 +226,7 @@ def parse_arguments():
         required=False,
         choices=["xlsx", "csv", "none"],
         default="csv",
-        help="Report format: 'csv' for a text-based report, 'xlsx' for an Excel spreadsheet, 'none' to skip report. Default: csv."
+        help="Report format: 'csv' for a text-based report, 'xlsx' for an Excel spreadsheet, 'none' to skip report"
     )
 
     return parser.parse_args()


### PR DESCRIPTION
Changes:

- Always generate the final report when processing multiple labs. If `--report` is specified as `None`., the single report for each lab is not created, but the final report that includes all the labs is created. 
- Fix help string.